### PR TITLE
Fixed email notifications toggle

### DIFF
--- a/Sources/Mentions.php
+++ b/Sources/Mentions.php
@@ -368,7 +368,7 @@ function Mentions_Profile($memID)
 	loadLanguage('Mentions');
 
 	if (!empty($_POST['save']) && $user_info['id'] == $memID)
-		updateMemberData($memID, array('email_mentions' => (bool) !empty($_POST['email_mentions'])));
+		updateMemberData($memID, array('email_mentions' => (integer) !empty($_POST['email_mentions'])));
 
 	if ($memID == $user_info['id'])
 	{


### PR DESCRIPTION
Hi,

first of all thank you for this really great mod!
I fixed an issue that was causing a DB error when a user tried to toggle/untoggle the email notifications in the Mentions section in the user's profile:

Error message:
MysqlError: Incorrect integer value: '' for column 'email_mentions' at row 1

Stack trace:
in mysql_query called at forum/Sources/Subs-Db-mysql.php (376)
in smf_db_query called at forum/Sources/Subs.php (556)
in updateMemberData called at forum/Sources/Mentions.php (371)
in Mentions_Profile called at forum/Sources/Profile.php (654)
in ModifyProfile called at ? (?)
in call_user_func called at forum/index.php (164)